### PR TITLE
Added helper to expose mapbox typings

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,7 +1,7 @@
-import React, { FunctionComponent } from "react";
-import styles from "./Header.module.scss";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import React, { FunctionComponent } from "react";
+import styles from "./Header.module.scss";
 
 interface Page {
   title: string | JSX.Element;

--- a/lib/azure-maps/mapbox.ts
+++ b/lib/azure-maps/mapbox.ts
@@ -1,0 +1,28 @@
+import type * as Atlas from "azure-maps-control";
+import type * as Mapbox from "mapbox-gl";
+
+/**
+ * Type forcibly removing the hidden private `.map` property from an `Atlas.Map`
+ * and intersects with a public `.map` property of type `Mapbox.Map`.
+ */
+export type MapWithMapbox = Omit<InstanceType<typeof Atlas.Map>, "map"> & {
+  map: InstanceType<typeof Mapbox.Map>;
+};
+
+/**
+ * Exposes the private `.map` `{Mapbox.Map}` instance in the passed in `map` with
+ * proper TypeScript typings.
+ *
+ * Does not modify the passed in map.
+ *
+ * @param {Atlas.Map} map the map instance to expose the mapbox instance of.
+ * @return {Promise<MapWithMapbox>} the passed in `map` instance with an exposed `.map` instance.
+ */
+export async function exposeMapbox(map: Atlas.Map): Promise<MapWithMapbox> {
+  // dynamically check for the map.map exists
+  if (typeof (map as any).map === "object" && (map as any).map) {
+    return (map as unknown) as MapWithMapbox;
+  }
+
+  throw Error(`unable to find .map mapbox instance in azure maps instance`);
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@types/geojson": "^7946.0.7",
     "@types/jest": "^26.0.14",
+    "@types/mapbox-gl": "^1.12.2",
     "@types/node": "^14.0.22",
     "@types/react": "^16.9.43",
     "@typescript-eslint/eslint-plugin": "^3.6.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,13 +9,13 @@
  * @see https://nextjs.org/docs/advanced-features/custom-app
  */
 ////////////////////////////////////////////////////////////////////////////////
+import "azure-maps-control/dist/atlas.css";
 import { AppProps } from "next/app";
-import React from "react";
 import Head from "next/head";
-import styles from "./_app.module.scss";
+import React from "react";
 import { Header } from "../components/Header";
 import "./styles.scss";
-import "azure-maps-control/dist/atlas.css";
+import styles from "./_app.module.scss";
 
 const MyApp = ({ Component, pageProps }: AppProps): JSX.Element => {
   return (

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -7,12 +7,12 @@
  */
 ////////////////////////////////////////////////////////////////////////////////
 import Document, {
-  Html,
-  Head,
-  Main,
-  NextScript,
   DocumentContext,
   DocumentInitialProps,
+  Head,
+  Html,
+  Main,
+  NextScript,
 } from "next/document";
 import React from "react";
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,15 +1,15 @@
-import Head from "next/head";
-import { NextMap } from "../components/Map";
-import React, { FunctionComponent } from "react";
-import type GeoJSON from "geojson";
-import { GetStaticProps } from "next";
 import * as fs from "fs/promises";
+import type GeoJSON from "geojson";
+import { GetStaticProps, NextPage } from "next";
+import Head from "next/head";
+import React from "react";
+import { NextMap } from "../components/Map";
 
 interface HomeProps {
   geoJSON: GeoJSON.GeoJSON[];
 }
 
-const Home: FunctionComponent<HomeProps> = (props) => {
+const Home: NextPage<HomeProps> = (props) => {
   return (
     <>
       <Head>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,7 +1394,7 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
-"@types/geojson@^7946.0.7":
+"@types/geojson@*", "@types/geojson@^7946.0.7":
   version "7946.0.7"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.7.tgz#c8fa532b60a0042219cdf173ca21a975ef0666ad"
   integrity sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==
@@ -1445,6 +1445,13 @@
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
+
+"@types/mapbox-gl@^1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@types/mapbox-gl/-/mapbox-gl-1.12.2.tgz#e30d9c745c4fbcdf8b6abe54a25f6f920a6d1639"
+  integrity sha512-5BjQ4wmRpz584qApgazma/6w2EB2evIaWKwZrDlshSX0+KoM8XT3nTrp8iYHQyMZV3mmIzEdbvt0jmc6ToLqeQ==
+  dependencies:
+    "@types/geojson" "*"
 
 "@types/node@*":
   version "14.11.5"


### PR DESCRIPTION
Added the `exposeMapbox` function which lifts the type of the passed in
mapbox instance and returns a instance `MapWithMapbox` which has proper
typings for the `map.map` instance.